### PR TITLE
Add flag to indicate relative fetch calls

### DIFF
--- a/ext/fetch/23_request.js
+++ b/ext/fetch/23_request.js
@@ -33,6 +33,7 @@
     ArrayPrototypeSlice,
     ArrayPrototypeSplice,
     ObjectKeys,
+    ObjectDefineProperty,
     ObjectPrototypeIsPrototypeOf,
     RegExpPrototypeTest,
     Symbol,
@@ -317,10 +318,12 @@
       let signal = null;
 
       // 5.
+      let isRelative = false;
       if (typeof input === "string") {
         let parsedURL;
         if (input.startsWith("/")) {
           parsedURL = new URL(input, baseURL);
+            isRelative = true;
         } else {
           try {
             // check if the input is a valid URL
@@ -351,7 +354,9 @@
         request = cloneInnerRequest(originalReq, true);
         request.redirectCount = 0; // reset to 0 - cloneInnerRequest copies the value
         signal = input[_signal];
+        isRelative = originalReq.isRelative;
       }
+      ObjectDefineProperty(request, "isRelative", {value: isRelative, writable: false, enumerable: false, configurable: false});
 
       // 12. is folded into the else statement of step 6 above.
 

--- a/ext/fetch/23_request.js
+++ b/ext/fetch/23_request.js
@@ -319,10 +319,8 @@
       // 5.
       if (typeof input === "string") {
         let parsedURL;
-        let additionalHeaders = [];
         if (input.startsWith("/")) {
           parsedURL = new URL(input, baseURL);
-          additionalHeaders = [["DT_IS_LOCAL_REQUEST", "true"]];
         } else {
           try {
             // check if the input is a valid URL
@@ -340,7 +338,7 @@
         request = newInnerRequest(
           () => "GET",
           parsedURL.href,
-          () => additionalHeaders,
+          () => [],
           null,
           true,
         );

--- a/ext/fetch/23_request.js
+++ b/ext/fetch/23_request.js
@@ -323,7 +323,7 @@
         let parsedURL;
         if (input.startsWith("/")) {
           parsedURL = new URL(input, baseURL);
-            isRelative = true;
+          isRelative = true;
         } else {
           try {
             // check if the input is a valid URL

--- a/ext/fetch/23_request.js
+++ b/ext/fetch/23_request.js
@@ -356,7 +356,13 @@
         signal = input[_signal];
         isRelative = originalReq.isRelative;
       }
-      ObjectDefineProperty(request, "isRelative", {value: isRelative, writable: false, enumerable: false, configurable: false});
+      // add `isRelative` as read-only property (instead of just doing
+      // `request.isRelative = isRelative;`) to prevent accidental or undesired changes
+      ObjectDefineProperty(request, "isRelative", {
+        value: isRelative,
+        writable: false,enumerable: false,
+        configurable: false
+      });
 
       // 12. is folded into the else statement of step 6 above.
 

--- a/ext/fetch/23_request.js
+++ b/ext/fetch/23_request.js
@@ -360,8 +360,9 @@
       // `request.isRelative = isRelative;`) to prevent accidental or undesired changes
       ObjectDefineProperty(request, "isRelative", {
         value: isRelative,
-        writable: false,enumerable: false,
-        configurable: false
+        writable: false,
+        enumerable: false,
+        configurable: false,
       });
 
       // 12. is folded into the else statement of step 6 above.

--- a/ext/fetch/26_fetch.js
+++ b/ext/fetch/26_fetch.js
@@ -413,7 +413,6 @@
     // awaiting `opPromise` in an inner function also named `fetch()` and
     // returning the result from that.
     let opPromise = undefined;
-
     // 1.
     const result = new Promise((resolve, reject) => {
       const prefix = "Failed to call 'fetch'";


### PR DESCRIPTION
This introduces a `isRelative` property on `InnerRequest` to indicate whether the corresponding `fetch()` was invoked with a relative URL.